### PR TITLE
timezone for reference reference

### DIFF
--- a/src/PrettyDateTime.php
+++ b/src/PrettyDateTime.php
@@ -55,7 +55,7 @@ class PrettyDateTime
     {
         // If not provided, set $reference to the current DateTime
         if (!$reference) {
-            $reference = new \DateTime('now');
+            $reference = new \DateTime(NULL, new \DateTimeZone($dateTime->getTimezone()->getName()));
         }
 
         // Get the difference between the current date and the supplied $dateTime


### PR DESCRIPTION
Hey man, if you do not provide alternate reference DateTime, it is better to create reference with the timezone of the supplied date. It is not good to rely on the default timezone of the scrip running. 
